### PR TITLE
Fix forward lps

### DIFF
--- a/src/main/kotlin/no/nav/syfo/client/HttpClientCommon.kt
+++ b/src/main/kotlin/no/nav/syfo/client/HttpClientCommon.kt
@@ -22,7 +22,6 @@ val commonConfig: HttpClientConfig<out HttpClientEngineConfig>.() -> Unit = {
         }
         constantDelay(REQUEST_RETRY_DELAY)
     }
-    expectSuccess = true
 }
 
 val proxyConfig: HttpClientConfig<ApacheEngineConfig>.() -> Unit = {

--- a/src/main/kotlin/no/nav/syfo/client/dokarkiv/DokarkivClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/dokarkiv/DokarkivClient.kt
@@ -77,7 +77,7 @@ class DokarkivClient(
         val token = azureAdClient.getSystemToken(scope)?.accessToken
             ?: throw RuntimeException("Failed to Journalfor: No token was found")
         val requestUrl = baseUrl + JOURNALPOST_API_PATH
-        val response = try {
+        val response = //try {
             client.post(requestUrl) {
                 headers {
                     append(HttpHeaders.ContentType, ContentType.Application.Json)
@@ -85,10 +85,13 @@ class DokarkivClient(
                 }
                 setBody(journalpostRequest)
             }
-        } catch (e: Exception) {
-            log.error("Could not send LPS plan to dokarkiv", e)
-            throw e
-        }
+        //        } catch (e: ResponseException) {
+        //            log.error("Could not send LPS plan to dokarkiv", e)
+        //            val responseStatus = e.response.status
+        //            throw e
+        //        }
+
+        log.info("qwqw: HTTP code er ${response.status.value}")
 
         val responseBody = when (response.status) {
             HttpStatusCode.Created -> {

--- a/src/main/kotlin/no/nav/syfo/client/dokarkiv/DokarkivClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/dokarkiv/DokarkivClient.kt
@@ -4,6 +4,7 @@ import io.ktor.client.call.body
 import io.ktor.client.request.headers
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
@@ -105,7 +106,7 @@ class DokarkivClient(
             }
 
             else -> {
-                log.error("Call to dokarkiv failed with status: ${response.status}")
+                log.error("Call to dokarkiv failed with status and message: ${response.status}, ${response.bodyAsText()}")
                 throw RuntimeException("Failed to call dokarkiv")
             }
         }

--- a/src/main/kotlin/no/nav/syfo/client/dokarkiv/DokarkivClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/dokarkiv/DokarkivClient.kt
@@ -106,7 +106,7 @@ class DokarkivClient(
             }
 
             else -> {
-                log.error("Call to Dokarkiv failed with status: ${response.status}, message: ${response.bodyAsText()}")
+                log.error("Call to Dokarkiv failed with status: ${response.status}, : ${response.bodyAsText()}")
                 throw RuntimeException("Failed to call dokarkiv")
             }
         }

--- a/src/main/kotlin/no/nav/syfo/client/dokarkiv/DokarkivClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/dokarkiv/DokarkivClient.kt
@@ -1,16 +1,15 @@
 package no.nav.syfo.client.dokarkiv
 
 import io.ktor.client.call.body
-import io.ktor.client.plugins.ResponseException
 import io.ktor.client.request.headers
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
-import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.append
 import java.util.*
+import kotlinx.coroutines.runBlocking
 import no.nav.syfo.altinnmottak.database.domain.AltinnLpsOppfolgingsplan
 import no.nav.syfo.application.environment.UrlEnv
 import no.nav.syfo.client.azuread.AzureAdClient
@@ -86,35 +85,35 @@ class DokarkivClient(
                 }
                 setBody(journalpostRequest)
             }
-        } catch (e: ResponseException) {
-            val errorResponse = e.response
-            when (errorResponse.status) {
-                HttpStatusCode.Conflict -> {
-                    log.warn("Journalpost for LPS plan already created!")
-                    val errorResponseBody = errorResponse.body<JournalpostResponse>()
-                    val id = errorResponseBody.journalpostId.toString()
-                    log.info("qwqw errorResponseBody $errorResponseBody")
-                    log.info("qwqw errorResponseBody.journalpostId ${errorResponseBody.journalpostId}")
-                    return id
-                }
+        } catch (e: Exception) {
+            log.error("Could not send LPS plan to dokarkiv", e)
+            throw e
+        }
 
-                else -> {
-                    log.error("Call to dokarkiv failed with status: ${errorResponse.status}")
-                    throw RuntimeException("Failed to call dokarkiv. Status: ${errorResponse.status}, message: ${errorResponse.bodyAsText()}")
+        val responseBody = when (response.status) {
+            HttpStatusCode.Created -> {
+                runBlocking {
+                    response.body<JournalpostResponse>()
                 }
+            }
+
+            HttpStatusCode.Conflict -> {
+                log.warn("Journalpost for LPS plan already created!")
+                runBlocking {
+                    response.body<JournalpostResponse>()
+                }
+            }
+
+            else -> {
+                log.error("Call to dokarkiv failed with status: ${response.status}")
+                throw RuntimeException("Failed to call dokarkiv")
             }
         }
 
-        log.info("qwqw HTTP code er ${response.status.value}")
-
-        if (response.status == HttpStatusCode.Created) {
-            val responseBody = response.body<JournalpostResponse>()
-            if (!responseBody.journalpostferdigstilt) {
-                log.warn("Journalpost is not ferdigstilt with message " + responseBody.melding)
-            }
-            return responseBody.journalpostId.toString()
+        if (!responseBody.journalpostferdigstilt) {
+            log.warn("Journalpost is not ferdigstilt with message " + responseBody.melding)
         }
-        throw Exception("qwqw Unknonwn HTTP response status code while requesting Dokarkiv")
+        return responseBody.journalpostId.toString()
     }
 
     private fun createAvsenderMottaker(

--- a/src/main/kotlin/no/nav/syfo/client/dokarkiv/DokarkivClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/dokarkiv/DokarkivClient.kt
@@ -106,7 +106,7 @@ class DokarkivClient(
             }
 
             else -> {
-                log.error("Call to dokarkiv failed with status and message: ${response.status}, ${response.bodyAsText()}")
+                log.error("Call to Dokarkiv failed with status: ${response.status}, message: ${response.bodyAsText()}")
                 throw RuntimeException("Failed to call dokarkiv")
             }
         }

--- a/src/main/kotlin/no/nav/syfo/client/ereg/EregClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/ereg/EregClient.kt
@@ -53,7 +53,7 @@ class EregClient(
             }
 
             else -> {
-                log.error("Call to get name by virksomhetsnummer from EREG failed with status: ${response.status}, message: ${response.bodyAsText()}")
+                log.error("Call to get name by virksomhetsnummer from EREG failed with status: ${response.status}, response body: ${response.bodyAsText()}")
                 null
             }
         }

--- a/src/main/kotlin/no/nav/syfo/client/ereg/EregClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/ereg/EregClient.kt
@@ -3,6 +3,7 @@ package no.nav.syfo.client.ereg
 import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.headers
+import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
@@ -52,7 +53,7 @@ class EregClient(
             }
 
             else -> {
-                log.error("Call to get name by virksomhetsnummer from EREG failed with status: ${response.status}")
+                log.error("Call to get name by virksomhetsnummer from EREG failed with status: ${response.status}, message: ${response.bodyAsText()}")
                 null
             }
         }

--- a/src/main/kotlin/no/nav/syfo/client/isdialogmelding/IsdialogmeldingClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/isdialogmelding/IsdialogmeldingClient.kt
@@ -61,7 +61,7 @@ class IsdialogmeldingClient(
             }
 
             else -> {
-                log.error("Call to to send LPS plan to fastlege failed with status: ${response.status}, message: ${response.bodyAsText()}")
+                log.error("Call to to send LPS plan to fastlege failed with status: ${response.status}, response body: ${response.bodyAsText()}")
                 false
             }
         }

--- a/src/main/kotlin/no/nav/syfo/client/isdialogmelding/IsdialogmeldingClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/isdialogmelding/IsdialogmeldingClient.kt
@@ -3,6 +3,7 @@ package no.nav.syfo.client.isdialogmelding
 import io.ktor.client.request.headers
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
@@ -60,7 +61,7 @@ class IsdialogmeldingClient(
             }
 
             else -> {
-                log.error("Unable to send LPS plan to fastlege (HTTP error code: ${response.status}")
+                log.error("Call to to send LPS plan to fastlege failed with status: ${response.status}, message: ${response.bodyAsText()}")
                 false
             }
         }

--- a/src/main/kotlin/no/nav/syfo/client/krrproxy/KrrProxyClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/krrproxy/KrrProxyClient.kt
@@ -56,7 +56,7 @@ class KrrProxyClient(
             }
 
             else -> {
-                log.error("Call to get  kontaktinfo from KRR-PROXY failed with status: ${response?.status}, WWW-Authenticate header:${response?.headers?.get("WWW-Authenticate")}, message: ${response?.bodyAsText()}")
+                log.error("Call to get  kontaktinfo from KRR-PROXY failed with status: ${response?.status}, WWW-Authenticate header:${response?.headers?.get("WWW-Authenticate")}, response body: ${response?.bodyAsText()}")
                 return null
             }
         }

--- a/src/main/kotlin/no/nav/syfo/client/krrproxy/KrrProxyClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/krrproxy/KrrProxyClient.kt
@@ -4,6 +4,7 @@ import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.headers
 import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
@@ -55,7 +56,7 @@ class KrrProxyClient(
             }
 
             else -> {
-                log.error("Could not get kontaktinfo from KRR-PROXY: $response, WWW-Authenticate header: ${response?.headers?.get("WWW-Authenticate")}")
+                log.error("Call to get  kontaktinfo from KRR-PROXY failed with status: ${response?.status}, WWW-Authenticate header:${response?.headers?.get("WWW-Authenticate")}, message: ${response?.bodyAsText()}")
                 return null
             }
         }

--- a/src/main/kotlin/no/nav/syfo/client/krrproxy/KrrProxyClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/krrproxy/KrrProxyClient.kt
@@ -37,7 +37,6 @@ class KrrProxyClient(
             }
         } catch (e: Exception) {
             log.error("Error while calling KRR-PROXY: ${e.message}, stacktrace ${e.printStackTrace()}", e)
-//            log.error("Could not get kontaktinfo from KRR-PROXY: $response, WWW-Authenticate header: ${response?.headers?.get("WWW-Authenticate")}")
 
             return null
         }

--- a/src/main/kotlin/no/nav/syfo/client/oppdfgen/OpPdfGenClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/oppdfgen/OpPdfGenClient.kt
@@ -104,7 +104,7 @@ class OpPdfGenClient(
             }
 
             else -> {
-                log.error("Call to generate PDF failed with status: ${response.status}, message: ${response.bodyAsText()}")
+                log.error("Call to generate PDF failed with status: ${response.status}, response body: ${response.bodyAsText()}")
                 null
             }
         }

--- a/src/main/kotlin/no/nav/syfo/client/oppdfgen/OpPdfGenClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/oppdfgen/OpPdfGenClient.kt
@@ -8,6 +8,7 @@ import io.ktor.client.call.body
 import io.ktor.client.request.headers
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
@@ -103,7 +104,7 @@ class OpPdfGenClient(
             }
 
             else -> {
-                log.error("Could not generate PDF. Call failed with status: ${response.status}")
+                log.error("Call to generate PDF failed with status: ${response.status}, message: ${response.bodyAsText()}")
                 null
             }
         }

--- a/src/main/kotlin/no/nav/syfo/client/pdl/PdlClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/pdl/PdlClient.kt
@@ -93,7 +93,7 @@ class PdlClient(
             }
 
             else -> {
-                log.error("Could not get person info from PDL: $response")
+                log.error("Call to  get person info from PDL failed with response: $response")
                 null
             }
         }

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -137,19 +137,23 @@ components:
           example: true
         needsHelpFromNav:
           type: "boolean"
-          description: "Do you need help from NAV? If yes, a task will be created at NAVs internal systems. Only relevant if the plan should be sent to NAV."
+          description: "Do you need help from NAV? If yes, a task will be created at NAV's internal systems. 
+          Only relevant if the plan should be sent to NAV, when sendPlanToNav is true. 
+          Must be false when sendPlanToNav is false."
           example: true
         needsHelpFromNavDescription:
           type: "string"
-          description: "Description of what kind of help is needed. Obligatory if needsHelpFromNav is true."
+          description: "Description of what kind of help is needed. 
+          Obligatory if needsHelpFromNav is true. 
+          Must be null if needsHelpFromNav is false."
           example: "Need assistance with job placement"
         sendPlanToGeneralPractitioner:
           type: "boolean"
-          description: "Do you want to send this plan to the employee's general practitioner?"
+          description: "Do you want to send this plan to the employee's general practitioner (fastlege)?"
           example: true
         messageToGeneralPractitioner:
           type: "string"
-          description: "Message to the general practitioner."
+          description: "Message to the general practitioner (fastlege)."
           example: "Please review the follow-up plan for the patient"
         additionalInformation:
           type: "string"
@@ -173,7 +177,9 @@ components:
           example: false
         employeeHasNotContributedToPlanDescription:
           type: "string"
-          description: "Description of why the employee does not have contributed to the plan. Obligatory if employeeHasContributedToPlan is false."
+          description: "Description of why the employee does not have contributed to the plan. 
+          Obligatory if employeeHasContributedToPlan is false.
+          Must be null if employeeHasContributedToPlan is true"
           example: "Employee was not available due to Sith business"
         lpsName:
           type: "string"
@@ -202,8 +208,8 @@ components:
           type: "string"
           description: "An id for a follow up plan"
         isSentToGeneralPractitionerStatus:
-          type: "string"
+          type: "boolean"
           description: "Status for sending a plan to general practitioner, true or false"
         isSentToNavStatus:
-          type: "string"
+          type: "boolean"
           description: "Status for sending a plan to NAV, true or false"


### PR DESCRIPTION
- Removed `expectSuccess = true` from `httpClientDefault()` to avoid throwing `ResponseException` and handle HTTP status instead. This will fix spamming errors produced by [forwarding of altinn-lps](https://logs.adeo.no/app/discover#/view/4ce734f0-9646-11eb-a3f3-5be089f1b0b9?_g=(filters:!(),refreshInterval:(pause:!f,value:10000),time:(from:'2024-04-05T00:47:42.806Z',to:'2024-04-17T22:00:00.000Z'))&_a=(columns:!(message,envclass,level,application,host),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'96e648c0-980a-11e9-830a-e17bbd64b4db',key:level,negate:!f,params:(query:Error),type:phrase),query:(match_phrase:(level:Error))),('$state':(store:appState),meta:(alias:!n,disabled:!f,field:application,index:'96e648c0-980a-11e9-830a-e17bbd64b4db',key:application,negate:!f,params:!(esyfovarsel,syfomotebehov,syfobrukertilgang,syfooppdfgen,syfo-mikrofrontend,syfooppfolgingsplanservice,lps-oppfolgingsplan-mottak),type:phrases,value:!(esyfovarsel,syfomotebehov,syfobrukertilgang,syfooppdfgen,syfo-mikrofrontend,syfooppfolgingsplanservice,lps-oppfolgingsplan-mottak)),query:(bool:(minimum_should_match:1,should:!((match_phrase:(application:esyfovarsel)),(match_phrase:(application:syfomotebehov)),(match_phrase:(application:syfobrukertilgang)),(match_phrase:(application:syfooppdfgen)),(match_phrase:(application:syfo-mikrofrontend)),(match_phrase:(application:syfooppfolgingsplanservice)),(match_phrase:(application:lps-oppfolgingsplan-mottak)))))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'96e648c0-980a-11e9-830a-e17bbd64b4db',key:envclass,negate:!f,params:(query:p),type:phrase),query:(match_phrase:(envclass:p)))),grid:(columns:(application:(width:273),envclass:(width:83),level:(width:112),message:(width:926))),hideChart:!f,index:'96e648c0-980a-11e9-830a-e17bbd64b4db',interval:auto,query:(language:lucene,query:'%22Could%20not%20forward%20altinn-lps%20with%20uuid%20d378740c-acde-4c4c-a976-ba4969a02aa8%20to%20DokArkiv%22'),sort:!(!('@timestamp',desc))))
This lps plan is already journalfort, and will be updated in our database with returned journalpost id(e.g. there will be no attempts to send this plan in future again)

- Unified logging error messages in clients.
