### PR TITLE
Verify integration endpoint

### DIFF
--- a/src/main/kotlin/no/nav/syfo/application/exception/AuthenticationException.kt
+++ b/src/main/kotlin/no/nav/syfo/application/exception/AuthenticationException.kt
@@ -1,4 +1,4 @@
 package no.nav.syfo.application.exception
 
-class AuthenticationException (message: String, cause: Throwable? = null) :
+class AuthenticationException(message: String, cause: Throwable? = null) :
     RuntimeException(message, cause)

--- a/src/main/kotlin/no/nav/syfo/application/exception/ConsumerClaimMissing.kt
+++ b/src/main/kotlin/no/nav/syfo/application/exception/ConsumerClaimMissing.kt
@@ -1,0 +1,3 @@
+package no.nav.syfo.application.exception
+
+class ConsumerClaimMissing : IllegalArgumentException("Consumer claim missing in token")

--- a/src/main/kotlin/no/nav/syfo/application/exception/SupplierClaimMissing.kt
+++ b/src/main/kotlin/no/nav/syfo/application/exception/SupplierClaimMissing.kt
@@ -1,0 +1,3 @@
+package no.nav.syfo.application.exception
+
+class SupplierClaimMissing : IllegalArgumentException("Supplier claim missing in token")

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplanmottak/FollowUpPlanApi.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplanmottak/FollowUpPlanApi.kt
@@ -1,17 +1,12 @@
 package no.nav.syfo.oppfolgingsplanmottak
 
-import io.ktor.http.HttpStatusCode
-import io.ktor.server.application.ApplicationCall
-import io.ktor.server.application.call
-import io.ktor.server.auth.authenticate
-import io.ktor.server.plugins.BadRequestException
-import io.ktor.server.request.receive
-import io.ktor.server.response.respond
-import io.ktor.server.routing.Routing
-import io.ktor.server.routing.get
-import io.ktor.server.routing.post
-import io.ktor.server.routing.route
-import java.util.*
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.auth.*
+import io.ktor.server.plugins.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
 import no.nav.syfo.application.api.auth.JwtIssuerType
 import no.nav.syfo.application.database.DatabaseInterface
 import no.nav.syfo.application.metric.COUNT_METRIKK_PROSSESERING_FOLLOWUP_LPS_PROSSESERING_VELLYKKET
@@ -24,6 +19,7 @@ import no.nav.syfo.util.getLpsOrgnumberFromClaims
 import no.nav.syfo.util.getOrgnumberFromClaims
 import no.nav.syfo.util.getSendingTimestamp
 import org.slf4j.LoggerFactory
+import java.util.*
 
 fun Routing.registerFollowUpPlanApi(
     database: DatabaseInterface,
@@ -89,7 +85,7 @@ fun Routing.registerFollowUpPlanApi(
             get("/{$uuid}/sendingstatus") {
                 try {
                     val sendingStatus = database.findSendingStatus(call.uuid())
-                    if (sendingStatus != null){
+                    if (sendingStatus != null) {
                         call.respond(sendingStatus)
                     } else {
                         call.respond(
@@ -114,10 +110,14 @@ fun Routing.registerFollowUpPlanApi(
                     )
                 }
             }
+
+            get("/verify-integration") {
+                call.respond(HttpStatusCode.OK, "Integration is up and running")
+            }
         }
     }
 }
 
 private fun ApplicationCall.uuid(): UUID =
     UUID.fromString(this.parameters["uuid"])
-    ?: throw IllegalArgumentException("Failed to fetch follow-up plan sending status: No valid follow-up plan uuid supplied in request")
+        ?: throw IllegalArgumentException("Failed to fetch follow-up plan sending status: No valid follow-up plan uuid supplied in request")

--- a/src/main/kotlin/no/nav/syfo/util/PipelineUtil.kt
+++ b/src/main/kotlin/no/nav/syfo/util/PipelineUtil.kt
@@ -6,6 +6,8 @@ import io.ktor.server.application.*
 import io.ktor.server.auth.*
 import io.ktor.server.auth.jwt.*
 import io.ktor.util.pipeline.*
+import no.nav.syfo.application.exception.ConsumerClaimMissing
+import no.nav.syfo.application.exception.SupplierClaimMissing
 import no.nav.syfo.domain.PersonIdent
 
 const val JWT_CLAIM_AZP = "azp"
@@ -26,16 +28,14 @@ fun ApplicationCall.getBearerHeader(): String? =
 
 fun PipelineContext<Unit, ApplicationCall>.getOrgnumberFromClaims(): String {
     val consumer = call.principal<JWTPrincipal>()?.payload?.getClaim("consumer")?.asMap()
-
-    requireNotNull(consumer)
+        ?: throw ConsumerClaimMissing()
 
     return maskinportenIdToOrgnumber(consumer["ID"] as String)
 }
 
 fun PipelineContext<Unit, ApplicationCall>.getLpsOrgnumberFromClaims(): String {
     val supplier = call.principal<JWTPrincipal>()?.payload?.getClaim("supplier")?.asMap()
-
-    requireNotNull(supplier)
+        ?: throw SupplierClaimMissing()
 
     return maskinportenIdToOrgnumber(supplier["ID"] as String)
 }

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -6,6 +6,7 @@ info:
 paths:
   /api/v1/followupplan:
     post:
+      summary: Submit follow-up plan
       description: "Submit follow-up plan to NAV and/or general practitioner"
       tags:
         - Followup-plan API
@@ -47,6 +48,7 @@ paths:
                 example: "Failed to retrieve follow-up plan: <Some error message>"
   /api/v1/followupplan/{uuid}/sendingstatus:
     get:
+      summary: Check sending status
       description: "Gets the sending status to NAV and general practitioner by follow up plan id"
       tags:
         - Followup-plan API
@@ -96,6 +98,8 @@ paths:
   /api/v1/followupplan/verify-integration:
     get:
       summary: Verify Integration
+      tags:
+        - Followup-plan API
       description: Endpoint to verify if the integration is up and running.
       responses:
         '200':

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -31,6 +31,13 @@ paths:
               schema:
                 type: "string"
                 example: "Invalid request. Error message: <Some error message>, Error cause: <Some cause>"
+        "401":
+          description: "Unauthorized"
+          content:
+            'text/plain':
+              schema:
+                type: "string"
+                example: "Missing supplier claim in JWT"
         "500":
           description: "Internal Server Error"
           content:
@@ -65,6 +72,13 @@ paths:
               schema:
                 type: "string"
                 example: "Invalid request. Error message: <Some error message>, Error cause: <Some cause>"
+        "401":
+          description: "Unauthorized"
+          content:
+            'text/plain':
+              schema:
+                type: "string"
+                example: "Missing supplier claim in JWT"
         "404":
           description: "NotFound"
           content:
@@ -79,6 +93,25 @@ paths:
               schema:
                 type: "string"
                 example: "Failed to retrieve follow-up plan: <Some error message>"
+  /api/v1/followupplan/verify-integration:
+    get:
+      summary: Verify Integration
+      description: Endpoint to verify if the integration is up and running.
+      responses:
+        '200':
+          description: "Integration is up and running"
+          content:
+            'text/plain':
+              schema:
+                type: "string"
+                example: "Integration is up and running"
+        "401":
+          description: "Unauthorized"
+          content:
+            'text/plain':
+              schema:
+                type: "string"
+                example: "Missing supplier claim in JWT"
 
 components:
   securitySchemes:

--- a/src/test/kotlin/no/nav/syfo/mockdata/TestApiModule.kt
+++ b/src/test/kotlin/no/nav/syfo/mockdata/TestApiModule.kt
@@ -1,6 +1,6 @@
 package no.nav.syfo.mockdata
 
-import io.ktor.server.application.Application
+import io.ktor.server.application.*
 import io.mockk.mockk
 import no.nav.syfo.application.api.apiModule
 import no.nav.syfo.application.database.DatabaseInterface


### PR DESCRIPTION
Nytt endepunkt som sjekker authorization og gir http 200 dersom alt er ok.

Jeg modda authorization litt, slik at den nå også sjekker at consumer og supplier finnes, og at den gir en feilmelding i body dersom noe er galt med validering av token.

Sjekk gjerne om dere synes dette er greit. Tror det kan hjelpe mye med oppsett av integrasjon, men selvfølgelig viktig at vi ikke lekker noe sensitiv data ved melding i autorisasjon. Jeg har kun returnert egendefinerte meldinger av typen AuthenticationException.