### PR TITLE
Disable gp exception for dev

### DIFF
--- a/nais/nais-dev.yaml
+++ b/nais/nais-dev.yaml
@@ -127,7 +127,7 @@ spec:
     - name: TOGGLE_SEND_LPS_PLAN_TO_NAV
       value: "true"
     - name: TOGGLE_SEND_LPS_PLAN_TO_FASTLEGE
-      value: "true"
+      value: "false"
     - name: TOGGLE_JOURNALFOR_LPS_PLAN
       value: "false"
     - name: TOGGLE_SEND_ALTINN_LPS_PLAN_TO_NAV


### PR DESCRIPTION
Det finnes ikke noe testmiljø som funker for å sende til fastlege i dev. Så vi får feil fra isyfo uansett.

Endrer til at vi sier den er sendt uansett, dersom det er i dev.