### PR TITLE
Enable journalforing to min side in dev

### DIFF
--- a/nais/nais-dev.yaml
+++ b/nais/nais-dev.yaml
@@ -119,9 +119,9 @@ spec:
     - name: ISDIALOGMELDING_CLIENT_ID
       value: dev-gcp.teamsykefravr.isdialogmelding
     - name: DOKARKIV_URL
-      value: https://dokarkiv.dev-fss-pub.nais.io
+      value: https://dokarkiv-q2.dev-fss-pub.nais.io
     - name: DOKARKIV_SCOPE
-      value: dev-fss.teamdokumenthandtering.dokarkiv-q1
+      value: dev-fss.teamdokumenthandtering.dokarkiv
     - name: ISTILGANGSKONTROLL_URL
       value: http://istilgangskontroll.teamsykefravr
     - name: ISTILGANGSKONTROLL_CLIENT_ID

--- a/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
+++ b/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
@@ -76,7 +76,8 @@ fun Application.apiModule(
         registerFollowUpPlanApi(
             database,
             followUpPlanSendingService,
-            FollowUpPlanValidator(pdlClient, sykmeldingService)
+            FollowUpPlanValidator(pdlClient, sykmeldingService),
+            environment
         )
         registerVeilederApi(
             veilederTilgangskontrollClient = veilederTilgangskontrollClient,

--- a/src/main/kotlin/no/nav/syfo/client/azuread/AzureAdClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/azuread/AzureAdClient.kt
@@ -10,10 +10,10 @@ import io.ktor.client.request.setBody
 import io.ktor.client.statement.HttpResponse
 import io.ktor.http.ContentType
 import io.ktor.http.Parameters
-import java.util.concurrent.ConcurrentHashMap
 import no.nav.syfo.application.environment.AuthEnv
 import no.nav.syfo.client.httpClientProxy
 import org.slf4j.LoggerFactory
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.collections.set
 
 @Suppress("ThrowsCount")

--- a/src/main/kotlin/no/nav/syfo/client/azuread/AzureAdToken.kt
+++ b/src/main/kotlin/no/nav/syfo/client/azuread/AzureAdToken.kt
@@ -4,7 +4,7 @@ import java.io.Serializable
 import java.time.LocalDateTime
 
 data class AzureAdToken(
-    val accessToken: String,
+    val accessToken: String?,
     val expires: LocalDateTime,
 ) : Serializable
 

--- a/src/main/kotlin/no/nav/syfo/client/azuread/AzureAdTokenResponse.kt
+++ b/src/main/kotlin/no/nav/syfo/client/azuread/AzureAdTokenResponse.kt
@@ -3,9 +3,9 @@ package no.nav.syfo.client.azuread
 import java.time.LocalDateTime
 @Suppress("ConstructorParameterNaming")
 data class AzureAdTokenResponse(
-    val access_token: String,
+    val access_token: String?,
     val expires_in: Long,
-    val token_type: String,
+    val token_type: String?,
 )
 
 fun AzureAdTokenResponse.toAzureAdToken(): AzureAdToken {

--- a/src/main/kotlin/no/nav/syfo/client/oppdfgen/OpPdfGenClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/oppdfgen/OpPdfGenClient.kt
@@ -85,6 +85,7 @@ class OpPdfGenClient(
         val requestBody = mapper.writeValueAsString(request)
 
         val response = try {
+            log.info("Calling PdfGen")
             client.post(requestUrl) {
                 headers {
                     append(HttpHeaders.ContentType, ContentType.Application.Json)
@@ -101,6 +102,7 @@ class OpPdfGenClient(
         return when (response.status) {
             HttpStatusCode.OK -> {
                 runBlocking {
+                    log.info("Successfully generated PDF for LPS-plan")
                     response.body<ByteArray>()
                 }
             }

--- a/src/main/kotlin/no/nav/syfo/maskinporten/MaskinportenTokenApi.kt
+++ b/src/main/kotlin/no/nav/syfo/maskinporten/MaskinportenTokenApi.kt
@@ -20,7 +20,7 @@ import no.nav.syfo.client.httpClientDefault
 import java.util.*
 
 private const val TWO_MINUTES_IN_SECONDS = 120
-private const val CONSUMER_ORG = "310069590"
+private const val CONSUMER_ORG = "889640782"
 private val httpClient = httpClientDefault()
 
 fun Routing.registerMaskinportenTokenApi(

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplanmottak/FollowUpPlanApi.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplanmottak/FollowUpPlanApi.kt
@@ -10,8 +10,10 @@ import io.ktor.server.routing.Routing
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
+import no.nav.syfo.application.ApplicationEnvironment
 import no.nav.syfo.application.api.auth.JwtIssuerType
 import no.nav.syfo.application.database.DatabaseInterface
+import no.nav.syfo.application.environment.isDev
 import no.nav.syfo.application.exception.ApiError.FollowupPlanNotFoundError
 import no.nav.syfo.application.metric.COUNT_METRIKK_PROSSESERING_FOLLOWUP_LPS_PROSSESERING_VELLYKKET
 import no.nav.syfo.oppfolgingsplanmottak.database.findSendingStatus
@@ -29,6 +31,7 @@ fun Routing.registerFollowUpPlanApi(
     database: DatabaseInterface,
     followUpPlanSendingService: FollowUpPlanSendingService,
     validator: FollowUpPlanValidator,
+    environment: ApplicationEnvironment,
 ) {
     val uuid = "uuid"
 
@@ -40,7 +43,7 @@ fun Routing.registerFollowUpPlanApi(
                 val employerOrgnr = getOrgnumberFromClaims()
                 val lpsOrgnumber = getLpsOrgnumberFromClaims() ?: employerOrgnr
 
-                validator.validateFollowUpPlanDTO(followUpPlanDTO, employerOrgnr)
+                validator.validateFollowUpPlanDTO(followUpPlanDTO, employerOrgnr, environment.isDev())
 
                 database.storeFollowUpPlan(
                     uuid = planUuid,

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplanmottak/validation/FollowUpPlanValidator.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplanmottak/validation/FollowUpPlanValidator.kt
@@ -11,7 +11,7 @@ class FollowUpPlanValidator(
     private val pdlClient: PdlClient,
     private val sykmeldingService: SendtSykmeldingService
 ) {
-    suspend fun validateFollowUpPlanDTO(followUpPlanDTO: FollowUpPlanDTO, employerOrgnr: String) {
+    suspend fun validateFollowUpPlanDTO(followUpPlanDTO: FollowUpPlanDTO, employerOrgnr: String, isDev: Boolean) {
         if (followUpPlanDTO.needsHelpFromNav == true && !followUpPlanDTO.sendPlanToNav) {
             throw FollowUpPlanDTOValidationException("needsHelpFromNav cannot be true if sendPlanToNav is false")
         }
@@ -36,7 +36,11 @@ class FollowUpPlanValidator(
         }
 
         val hasActiveSendtSykmelding =
-            sykmeldingService.hasActiveSentSykmelding(employerOrgnr, followUpPlanDTO.employeeIdentificationNumber)
+            sykmeldingService.hasActiveSentSykmelding(
+                employerOrgnr,
+                followUpPlanDTO.employeeIdentificationNumber,
+                isDev
+            )
 
         validateEmployeeInformation(followUpPlanDTO.employeeIdentificationNumber, hasActiveSendtSykmelding)
     }

--- a/src/main/kotlin/no/nav/syfo/sykmelding/service/SendtSykmeldingService.kt
+++ b/src/main/kotlin/no/nav/syfo/sykmelding/service/SendtSykmeldingService.kt
@@ -46,7 +46,12 @@ class SendtSykmeldingService(private val database: DatabaseInterface) {
     fun hasActiveSentSykmelding(
         orgnumber: String,
         employeeIdentificationNumber: String,
+        isDev: Boolean,
     ): Boolean {
+        if (isDev) {
+            return true
+        }
+
         return database.hasActiveSentSykmelding(
             orgnumber,
             employeeIdentificationNumber

--- a/src/test/kotlin/no/nav/syfo/sykmelding/service/SendtSykmeldingServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/sykmelding/service/SendtSykmeldingServiceTest.kt
@@ -105,7 +105,7 @@ class SendtSykmeldingServiceTest : DescribeSpec({
             )
 
             val hasActiveSentSykmelding =
-                sendtSykmeldingService.hasActiveSentSykmelding(orgnumber, employeeIdentificationNumber)
+                sendtSykmeldingService.hasActiveSentSykmelding(orgnumber, employeeIdentificationNumber, false)
 
             hasActiveSentSykmelding shouldBe true
         }
@@ -129,7 +129,7 @@ class SendtSykmeldingServiceTest : DescribeSpec({
             )
 
             val hasActiveSentSykmelding =
-                sendtSykmeldingService.hasActiveSentSykmelding(orgnumber, employeeIdentificationNumber)
+                sendtSykmeldingService.hasActiveSentSykmelding(orgnumber, employeeIdentificationNumber, false)
 
             hasActiveSentSykmelding shouldBe false
         }


### PR DESCRIPTION
Fikser journalføring slik at vi kan se innsendt skjema (PDF) på min side i dev.

- Bruker nå et nytt orgnummer (det var noe tull med gammelt org i dolly/tenor)
- Journalfører nå til Dokarkiv sitt Q2 miljø (det er kun det som dukker opp på min side)
- Fikser feilaktig DTO for Azure token
- Legger på litt ekstra logging. Tenker vi kan beholde den en stund, og evnt fjerne noen når ting kjører smooth i prod.