### PR TITLE
Fix data type for Paging

### DIFF
--- a/src/main/kotlin/no/nav/syfo/client/pdl/domain/PdlRequest.kt
+++ b/src/main/kotlin/no/nav/syfo/client/pdl/domain/PdlRequest.kt
@@ -22,8 +22,8 @@ data class SokAdresseVariables(
 )
 
 data class Paging(
-    val pageNumber: String? = "1",
-    val resultsPerPage: String? = "1",
+    val pageNumber: Int? = 1,
+    val resultsPerPage: Int? = 1,
 )
 
 data class SearchRule(


### PR DESCRIPTION
Feilmelding ved request til PDL:

Could not get poststed from PDL, response contains errors: [PdlError(message=Variable 'paging' has an invalid value: Expected a value that can be converted to type 'Int' but it was a 'String', locations=[PdlErrorLocation(line=1, column=8)], path=null, extensions=PdlErrorExtension(code=null, classification=ValidationError))]