### PR TITLE
avoid wrong navn in AvsenderMottaker

### DIFF
--- a/src/main/kotlin/no/nav/syfo/client/dokarkiv/DokarkivClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/dokarkiv/DokarkivClient.kt
@@ -45,13 +45,13 @@ class DokarkivClient(
         pdf: ByteArray,
         uuid: UUID,
     ): String {
-        val avsenderMottaker = createAvsenderMottaker(employerOrgnr, employerOrgnr)
-        val orgName = eregClient.getEmployerOrganisationName(employerOrgnr) ?: employerOrgnr
+        val orgName = eregClient.getEmployerOrganisationName(employerOrgnr)
+        val avsenderMottaker = createAvsenderMottaker(employerOrgnr, orgName)
 
         val journalpostRequest = createJournalpostRequest(
             followUpPlan.employeeIdentificationNumber,
             pdf,
-            navn = orgName,
+            navn = orgName ?: employerOrgnr ,
             avsenderMottaker,
             "NAV_NO",
             uuid.toString(),
@@ -63,7 +63,7 @@ class DokarkivClient(
         lps: AltinnLpsOppfolgingsplan,
         virksomhetsnavn: String,
     ): String {
-        val avsenderMottaker = createAvsenderMottaker(lps.orgnummer, virksomhetsnavn)
+        val avsenderMottaker = createAvsenderMottaker(lps.orgnummer)
         val journalpostRequest = createJournalpostRequest(
             lps.fnr!!,
             lps.pdf!!,
@@ -124,7 +124,7 @@ class DokarkivClient(
 
     private fun createAvsenderMottaker(
         orgnummer: String,
-        virksomhetsnavn: String,
+        virksomhetsnavn: String? = null,
     ) = AvsenderMottaker(
         id = orgnummer,
         idType = ID_TYPE_ORGNR,

--- a/src/main/kotlin/no/nav/syfo/client/dokarkiv/domain/AvsenderMottaker.kt
+++ b/src/main/kotlin/no/nav/syfo/client/dokarkiv/domain/AvsenderMottaker.kt
@@ -3,5 +3,5 @@ package no.nav.syfo.client.dokarkiv.domain
 data class AvsenderMottaker(
     val id: String,
     val idType: String,
-    val navn: String, // Navnet til avsender/mottaker. Skal være på format Fornavn Mellomnavn Etternavn.
+    val navn: String?, // when idType is ORGNR and navn is null joark will look up the name
 )


### PR DESCRIPTION
Fra team dokumentløsninger:
"Ved kall til opprettJournalpost og oppdaterJournalpost hvor avsender/mottaker er en norsk organisasjon og navn på avsender/mottaker ikke er satt i requesten, vil navnet nå hentes fra Ereg. Dersom tjenesten ikke klarer å hente et gyldig navn fortsetter behandling av kallet uten navn."