### PR TITLE
More logs for arbeidsforhold.

### DIFF
--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplanmottak/FollowUpPlanApi.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplanmottak/FollowUpPlanApi.kt
@@ -43,6 +43,7 @@ fun Routing.registerFollowUpPlanApi(
                 val employerOrgnr = getOrgnumberFromClaims()
                 val lpsOrgnumber = getLpsOrgnumberFromClaims() ?: employerOrgnr
 
+                log.info("Validating follow-up plan for employer $employerOrgnr and LPS orgnumber $lpsOrgnumber")
                 validator.validateFollowUpPlanDTO(followUpPlanDTO, employerOrgnr)
                 log.info("Follow-up plan is valid. Attempting to store plan.")
 

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplanmottak/validation/FollowUpPlanValidator.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplanmottak/validation/FollowUpPlanValidator.kt
@@ -9,6 +9,7 @@ import no.nav.syfo.client.pdl.PdlClient
 import no.nav.syfo.oppfolgingsplanmottak.domain.FollowUpPlanDTO
 import no.nav.syfo.sykmelding.domain.Sykmeldingsperiode
 import no.nav.syfo.sykmelding.service.SendtSykmeldingService
+import org.slf4j.LoggerFactory
 
 val TEST_FNR_LIST = listOf("05908399546", "01898299631")
 
@@ -18,6 +19,8 @@ class FollowUpPlanValidator(
     private val arbeidsforholdOversiktClient: ArbeidsforholdOversiktClient,
     private val isDev: Boolean,
 ) {
+    private val log = LoggerFactory.getLogger(FollowUpPlanValidator::class.java)
+
     suspend fun validateFollowUpPlanDTO(
         followUpPlanDTO: FollowUpPlanDTO,
         employerOrgnr: String,
@@ -96,6 +99,12 @@ class FollowUpPlanValidator(
         val arbeidsforholdOversikt =
             arbeidsforholdOversiktClient.getArbeidsforhold(followUpPlanDTO.employeeIdentificationNumber)
 
+        if(arbeidsforholdOversikt!= null && arbeidsforholdOversikt.arbeidsforholdoversikter.isNotEmpty()) {
+            arbeidsforholdOversikt.arbeidsforholdoversikter.forEach {
+                log.info("Found arbeidsforhold in orgnumber:" +
+                        " ${it.opplysningspliktig.getJuridiskOrgnummer()} and ${it.arbeidssted.getOrgnummer()}")
+            }
+        }
         val matchingArbeidsforhold =
             arbeidsforholdOversikt?.arbeidsforholdoversikter?.filter {
                 it.opplysningspliktig.getJuridiskOrgnummer() == employerOrgnr ||
@@ -103,7 +112,9 @@ class FollowUpPlanValidator(
             } ?: emptyList()
 
         if (matchingArbeidsforhold.isEmpty()) {
-            throw NoActiveEmploymentException("No active employment relationship found for given orgnumber")
+            throw NoActiveEmploymentException(
+                "No active employment relationship found for given orgnumber: $employerOrgnr"
+            )
         }
 
         val validOrgnumbers =

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplanmottak/validation/FollowUpPlanValidator.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplanmottak/validation/FollowUpPlanValidator.kt
@@ -99,12 +99,6 @@ class FollowUpPlanValidator(
         val arbeidsforholdOversikt =
             arbeidsforholdOversiktClient.getArbeidsforhold(followUpPlanDTO.employeeIdentificationNumber)
 
-        if(arbeidsforholdOversikt!= null && arbeidsforholdOversikt.arbeidsforholdoversikter.isNotEmpty()) {
-            arbeidsforholdOversikt.arbeidsforholdoversikter.forEach {
-                log.info("Found arbeidsforhold in orgnumber:" +
-                        " ${it.opplysningspliktig.getJuridiskOrgnummer()} and ${it.arbeidssted.getOrgnummer()}")
-            }
-        }
         val matchingArbeidsforhold =
             arbeidsforholdOversikt?.arbeidsforholdoversikter?.filter {
                 it.opplysningspliktig.getJuridiskOrgnummer() == employerOrgnr ||
@@ -112,8 +106,14 @@ class FollowUpPlanValidator(
             } ?: emptyList()
 
         if (matchingArbeidsforhold.isEmpty()) {
+            arbeidsforholdOversikt?.arbeidsforholdoversikter?.forEach {
+                log.info(
+                    "Found arbeidsforhold in orgnumber:" +
+                        " ${it.opplysningspliktig.getJuridiskOrgnummer()} and ${it.arbeidssted.getOrgnummer()}",
+                )
+            }
             throw NoActiveEmploymentException(
-                "No active employment relationship found for given orgnumber: $employerOrgnr"
+                "No active employment relationship found for given orgnumber: $employerOrgnr",
             )
         }
 


### PR DESCRIPTION
<!-- Managed by esyfo-cli. Do not edit manually. Changes will be overwritten.
     For repo-specific customizations, create your own files without this header. -->
## Beskrivelse

Bjørn har en hypotese som jeg er enig i, LPS sender med maskinportentoken som kun inkluderer deres ORGnumber og ikke kunden sin. 
Vi logger nå mer for å bekrefte dette. Så vi kan be dem både sjekke og resende på nytt. Og vi har bedre grunnlag for å svare. 


## Endringer

<!-- - `fil/modul`: Hva som ble endret -->

## Issue

<!-- Closes #NUMMER / Relates to #NUMMER -->

## Sjekkliste

- [ ] Koden kompilerer og linter uten feil
- [ ] Endringene er testet (manuelt eller automatisk)
- [ ] Ingen sensitiv data eksponert (tokens, credentials, PII)
