### PR TITLE
fix: godta organisasjonsledd som gyldig arbeidsgiver ved innsending av oppfølgingsplan

### DIFF
--- a/src/main/kotlin/no/nav/syfo/App.kt
+++ b/src/main/kotlin/no/nav/syfo/App.kt
@@ -161,6 +161,7 @@ private fun setModule(
             pdlClient,
             sykmeldingService,
             arbeidsforholdOversiktClient,
+            eregClient,
         )
         kafkaModule(
             appState,

--- a/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
+++ b/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
@@ -18,6 +18,7 @@ import no.nav.syfo.application.database.DatabaseInterface
 import no.nav.syfo.application.environment.isDev
 import no.nav.syfo.application.metric.registerPrometheusApi
 import no.nav.syfo.client.aareg.ArbeidsforholdOversiktClient
+import no.nav.syfo.client.ereg.EregClient
 import no.nav.syfo.client.pdl.PdlClient
 import no.nav.syfo.client.veiledertilgang.VeilederTilgangskontrollClient
 import no.nav.syfo.client.wellknown.WellKnown
@@ -40,6 +41,7 @@ fun Application.apiModule(
     pdlClient: PdlClient,
     sykmeldingService: SendtSykmeldingService,
     arbeidsforholdOversiktClient: ArbeidsforholdOversiktClient,
+    eregClient: EregClient,
 ) {
     installMetrics()
     installCallId()
@@ -78,7 +80,13 @@ fun Application.apiModule(
         registerFollowUpPlanApi(
             database,
             followUpPlanSendingService,
-            FollowUpPlanValidator(pdlClient, sykmeldingService, arbeidsforholdOversiktClient, environment.isDev()),
+            FollowUpPlanValidator(
+                pdlClient,
+                sykmeldingService,
+                arbeidsforholdOversiktClient,
+                eregClient,
+                environment.isDev(),
+            ),
         )
         registerVeilederApi(
             veilederTilgangskontrollClient = veilederTilgangskontrollClient,

--- a/src/main/kotlin/no/nav/syfo/client/ereg/EregClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/ereg/EregClient.kt
@@ -3,6 +3,7 @@ package no.nav.syfo.client.ereg
 import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.headers
+import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
@@ -11,6 +12,7 @@ import io.ktor.http.append
 import no.nav.syfo.application.environment.ApplicationEnv
 import no.nav.syfo.application.environment.UrlEnv
 import no.nav.syfo.client.azuread.AzureAdClient
+import no.nav.syfo.client.ereg.domain.EregOrganisasjon
 import no.nav.syfo.client.ereg.domain.EregOrganisasjonResponse
 import no.nav.syfo.client.ereg.domain.getNavn
 import no.nav.syfo.client.httpClientDefault
@@ -30,29 +32,33 @@ class EregClient(
     private val client = httpClientDefault()
     private val log = LoggerFactory.getLogger(EregClient::class.qualifiedName)
 
-    private suspend fun getOrganisationInformation(orgnr: String): EregOrganisasjonResponse? {
-        val response =
-            try {
-                client.get("$eregBaseUrl/ereg/api/v2/organisasjon/$orgnr") {
-                    val token =
-                        azureAdClient.getSystemToken(scope)?.accessToken
-                            ?: throw RuntimeException("Failed to fetch organization name from EREG: No token was found")
-                    headers {
-                        append(HttpHeaders.ContentType, ContentType.Application.Json)
-                        append(HttpHeaders.Authorization, createBearerToken(token))
-                        append(NAV_CONSUMER_ID_HEADER, appEnv.appName)
-                        append(NAV_CALL_ID_HEADER, createCallId())
-                    }
+    private suspend fun hentOrganisasjon(
+        orgnr: String,
+        inkluderHierarki: Boolean = false,
+    ): HttpResponse {
+        val query = if (inkluderHierarki) "?inkluderHierarki=true" else ""
+        return try {
+            client.get("$eregBaseUrl/ereg/api/v2/organisasjon/$orgnr$query") {
+                val token =
+                    azureAdClient.getSystemToken(scope)?.accessToken
+                        ?: throw RuntimeException("Failed to fetch organization from EREG: No token was found")
+                headers {
+                    append(HttpHeaders.ContentType, ContentType.Application.Json)
+                    append(HttpHeaders.Authorization, createBearerToken(token))
+                    append(NAV_CONSUMER_ID_HEADER, appEnv.appName)
+                    append(NAV_CALL_ID_HEADER, createCallId())
                 }
-            } catch (e: Exception) {
-                log.error("Could not fetch organization name form EREG", e)
-                throw e
             }
-        return when (response.status) {
-            HttpStatusCode.OK -> {
-                response.body<EregOrganisasjonResponse>()
-            }
+        } catch (e: Exception) {
+            log.error("Could not fetch organization from EREG", e)
+            throw e
+        }
+    }
 
+    private suspend fun getOrganisationInformation(orgnr: String): EregOrganisasjonResponse? {
+        val response = hentOrganisasjon(orgnr)
+        return when (response.status) {
+            HttpStatusCode.OK -> response.body<EregOrganisasjonResponse>()
             else -> {
                 log.error(
                     "Call to get name by virksomhetsnummer from EREG failed with status:" +
@@ -64,4 +70,25 @@ class EregClient(
     }
 
     suspend fun getEmployerOrganisationName(orgnr: String): String? = getOrganisationInformation(orgnr)?.getNavn()
+
+    /**
+     * Henter organisasjonen med fullt hierarki (`?inkluderHierarki=true`), slik at underenhetens
+     * organisasjonsledd og juridiske enheter er tilgjengelige. Brukes til å avgjøre om et oppgitt
+     * orgnummer er en gyldig overordnet enhet for arbeidsstedet.
+     *
+     * Skiller mellom genuint fravær (404 -> null, korrekt å avvise) og utilgjengelighet (annet enn
+     * 200/404 -> kastes, slik at en forbigående ereg-feil blir 500 og kan prøves på nytt — i stedet
+     * for et villedende 403 om at arbeidsforholdet ikke finnes).
+     */
+    suspend fun getOrganisasjonHierarki(orgnr: String): EregOrganisasjon? {
+        val response = hentOrganisasjon(orgnr, inkluderHierarki = true)
+        return when (response.status) {
+            HttpStatusCode.OK -> response.body<EregOrganisasjon>()
+            HttpStatusCode.NotFound -> null
+            else ->
+                throw RuntimeException(
+                    "EREG hierarki lookup failed with status: ${response.status}",
+                )
+        }
+    }
 }

--- a/src/main/kotlin/no/nav/syfo/client/ereg/domain/EregOrganisasjonHierarki.kt
+++ b/src/main/kotlin/no/nav/syfo/client/ereg/domain/EregOrganisasjonHierarki.kt
@@ -1,0 +1,88 @@
+package no.nav.syfo.client.ereg.domain
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import java.time.LocalDate
+
+/**
+ * Modell for ereg-responsen `GET /ereg/api/v2/organisasjon/{orgnr}?inkluderHierarki=true`.
+ *
+ * aaregs arbeidsforholdoversikt er to-nivå (arbeidssted + opplysningspliktig/juridisk enhet) og
+ * utelater eventuelle organisasjonsledd som ligger imellom. For offentlige arbeidsgivere kan
+ * Maskinporten-tokenet være utstedt på et slikt organisasjonsledd. Denne modellen lar oss slå opp
+ * arbeidsstedets fulle hierarki og avgjøre om et oppgitt orgnummer er en gyldig overordnet enhet.
+ *
+ * Hver relasjon har en [EregGyldighetsperiode]; kun relasjoner som er gyldige i dag tas med, slik at
+ * et historisk (avsluttet) tilhørighetsforhold ikke gir tilgang.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class EregOrganisasjon(
+    val organisasjonsnummer: String,
+    val inngaarIJuridiskEnheter: List<EregEnhetsRelasjon>? = null,
+    val bestaarAvOrganisasjonsledd: List<EregOrganisasjonsleddWrapper>? = null,
+) {
+    /**
+     * Samler alle organisasjonsnummer i hierarkiet over (og inkludert) denne enheten:
+     * enheten selv, juridiske enheter den inngår i, og organisasjonsledd den består av (rekursivt).
+     * Utløpte relasjoner ekskluderes.
+     */
+    fun aggregerOrgnummereFraHierarki(): Set<String> {
+        val orgnummere = mutableSetOf(organisasjonsnummer)
+        inngaarIJuridiskEnheter
+            ?.filter { it.gyldighetsperiode.erGyldigNaa() }
+            ?.mapTo(orgnummere) { it.organisasjonsnummer }
+        bestaarAvOrganisasjonsledd
+            ?.filter { it.gyldighetsperiode.erGyldigNaa() }
+            ?.forEach { orgnummere.addAll(it.organisasjonsledd.collectOrgnummer()) }
+        return orgnummere
+    }
+}
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class EregOrganisasjonsleddWrapper(
+    val organisasjonsledd: EregOrganisasjonsledd,
+    val gyldighetsperiode: EregGyldighetsperiode? = null,
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class EregOrganisasjonsledd(
+    val organisasjonsnummer: String,
+    val inngaarIJuridiskEnheter: List<EregEnhetsRelasjon>? = null,
+    val organisasjonsleddOver: List<EregOrganisasjonsleddWrapper>? = null,
+) {
+    fun collectOrgnummer(visited: MutableSet<String> = mutableSetOf()): Set<String> {
+        if (!visited.add(organisasjonsnummer)) {
+            return emptySet()
+        }
+        val orgnummere = mutableSetOf(organisasjonsnummer)
+        inngaarIJuridiskEnheter
+            ?.filter { it.gyldighetsperiode.erGyldigNaa() }
+            ?.mapTo(orgnummere) { it.organisasjonsnummer }
+        organisasjonsleddOver
+            ?.filter { it.gyldighetsperiode.erGyldigNaa() }
+            ?.forEach { orgnummere.addAll(it.organisasjonsledd.collectOrgnummer(visited)) }
+        return orgnummere
+    }
+}
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class EregEnhetsRelasjon(
+    val organisasjonsnummer: String,
+    val gyldighetsperiode: EregGyldighetsperiode? = null,
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class EregGyldighetsperiode(
+    val fom: String? = null,
+    val tom: String? = null,
+) {
+    fun erGyldig(idag: LocalDate = LocalDate.now()): Boolean {
+        val startet = fom?.let { !parseDato(it).isAfter(idag) } ?: true
+        val ikkeUtloept = tom?.let { !parseDato(it).isBefore(idag) } ?: true
+        return startet && ikkeUtloept
+    }
+
+    private fun parseDato(verdi: String): LocalDate = LocalDate.parse(verdi.take(10))
+}
+
+/** En manglende gyldighetsperiode regnes som gyldig (fail-closed kun på eksplisitt utløpte relasjoner). */
+fun EregGyldighetsperiode?.erGyldigNaa(): Boolean = this?.erGyldig() ?: true

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplanmottak/validation/FollowUpPlanValidator.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplanmottak/validation/FollowUpPlanValidator.kt
@@ -5,6 +5,8 @@ import no.nav.syfo.application.exception.FollowUpPlanDTOValidationException
 import no.nav.syfo.application.exception.NoActiveEmploymentException
 import no.nav.syfo.application.exception.NoActiveSentSykmeldingException
 import no.nav.syfo.client.aareg.ArbeidsforholdOversiktClient
+import no.nav.syfo.client.aareg.domain.Arbeidsforholdoversikt
+import no.nav.syfo.client.ereg.EregClient
 import no.nav.syfo.client.pdl.PdlClient
 import no.nav.syfo.oppfolgingsplanmottak.domain.FollowUpPlanDTO
 import no.nav.syfo.sykmelding.domain.Sykmeldingsperiode
@@ -17,6 +19,7 @@ class FollowUpPlanValidator(
     private val pdlClient: PdlClient,
     private val sykmeldingService: SendtSykmeldingService,
     private val arbeidsforholdOversiktClient: ArbeidsforholdOversiktClient,
+    private val eregClient: EregClient,
     private val isDev: Boolean,
 ) {
     private val log = LoggerFactory.getLogger(FollowUpPlanValidator::class.java)
@@ -96,17 +99,16 @@ class FollowUpPlanValidator(
         followUpPlanDTO: FollowUpPlanDTO,
         employerOrgnr: String,
     ): List<String?> {
-        val arbeidsforholdOversikt =
-            arbeidsforholdOversiktClient.getArbeidsforhold(followUpPlanDTO.employeeIdentificationNumber)
+        val arbeidsforhold =
+            arbeidsforholdOversiktClient
+                .getArbeidsforhold(followUpPlanDTO.employeeIdentificationNumber)
+                ?.arbeidsforholdoversikter
+                ?: emptyList()
 
-        val matchingArbeidsforhold =
-            arbeidsforholdOversikt?.arbeidsforholdoversikter?.filter {
-                it.opplysningspliktig.getJuridiskOrgnummer() == employerOrgnr ||
-                    it.arbeidssted.getOrgnummer() == employerOrgnr
-            } ?: emptyList()
+        val matchingArbeidsforhold = findMatchingArbeidsforhold(arbeidsforhold, employerOrgnr)
 
         if (matchingArbeidsforhold.isEmpty()) {
-            arbeidsforholdOversikt?.arbeidsforholdoversikter?.forEach {
+            arbeidsforhold.forEach {
                 log.info(
                     "Found arbeidsforhold in orgnumber:" +
                         " ${it.opplysningspliktig.getJuridiskOrgnummer()} and ${it.arbeidssted.getOrgnummer()}",
@@ -117,14 +119,48 @@ class FollowUpPlanValidator(
             )
         }
 
-        val validOrgnumbers =
-            matchingArbeidsforhold
-                .flatMap {
-                    listOf(
-                        it.opplysningspliktig.getJuridiskOrgnummer(),
-                        it.arbeidssted.getOrgnummer(),
-                    )
-                }.distinct()
-        return validOrgnumbers
+        return matchingArbeidsforhold
+            .flatMap {
+                listOf(
+                    it.opplysningspliktig.getJuridiskOrgnummer(),
+                    it.arbeidssted.getOrgnummer(),
+                )
+            }.distinct()
+    }
+
+    /**
+     * Finner arbeidsforhold som hører til [employerOrgnr]. Først direkte match mot juridisk enhet
+     * (opplysningspliktig) eller arbeidssted (underenhet). Hvis ingen direkte match: slår opp
+     * arbeidsstedets hierarki i ereg og godtar arbeidsforhold der [employerOrgnr] er en gyldig
+     * overordnet enhet — typisk et organisasjonsledd som ligger mellom underenhet og juridisk enhet,
+     * og som ikke finnes i aaregs to-nivå-modell.
+     */
+    private suspend fun findMatchingArbeidsforhold(
+        arbeidsforhold: List<Arbeidsforholdoversikt>,
+        employerOrgnr: String,
+    ): List<Arbeidsforholdoversikt> {
+        val directMatches =
+            arbeidsforhold.filter {
+                it.opplysningspliktig.getJuridiskOrgnummer() == employerOrgnr ||
+                    it.arbeidssted.getOrgnummer() == employerOrgnr
+            }
+        if (directMatches.isNotEmpty()) {
+            return directMatches
+        }
+
+        // Ett ereg-oppslag per unikt arbeidssted (ikke per arbeidsforhold) for å unngå duplikate kall.
+        val matchendeArbeidssteder = mutableSetOf<String>()
+        for (arbeidsstedOrgnr in arbeidsforhold.mapNotNull { it.arbeidssted.getOrgnummer() }.distinct()) {
+            val hierarkiOrgnumre =
+                eregClient.getOrganisasjonHierarki(arbeidsstedOrgnr)?.aggregerOrgnummereFraHierarki().orEmpty()
+            if (employerOrgnr in hierarkiOrgnumre) {
+                log.info(
+                    "Matched employer $employerOrgnr as overordnet enhet for arbeidssted" +
+                        " $arbeidsstedOrgnr via ereg hierarki",
+                )
+                matchendeArbeidssteder.add(arbeidsstedOrgnr)
+            }
+        }
+        return arbeidsforhold.filter { it.arbeidssted.getOrgnummer() in matchendeArbeidssteder }
     }
 }

--- a/src/test/kotlin/no/nav/syfo/client/ereg/domain/EregOrganisasjonHierarkiTest.kt
+++ b/src/test/kotlin/no/nav/syfo/client/ereg/domain/EregOrganisasjonHierarkiTest.kt
@@ -1,0 +1,133 @@
+package no.nav.syfo.client.ereg.domain
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+
+class EregOrganisasjonHierarkiTest :
+    DescribeSpec({
+        describe("aggregerOrgnummereFraHierarki") {
+            it("includes underenhet, organisasjonsledd and juridisk enhet from the hierarchy") {
+                val hierarki =
+                    EregOrganisasjon(
+                        organisasjonsnummer = "895225282",
+                        bestaarAvOrganisasjonsledd =
+                            listOf(
+                                EregOrganisasjonsleddWrapper(
+                                    organisasjonsledd =
+                                        EregOrganisasjonsledd(
+                                            organisasjonsnummer = "976679512",
+                                            inngaarIJuridiskEnheter = listOf(EregEnhetsRelasjon("938801363")),
+                                        ),
+                                ),
+                            ),
+                    )
+
+                hierarki.aggregerOrgnummereFraHierarki() shouldBe setOf("895225282", "976679512", "938801363")
+            }
+
+            it("walks nested organisasjonsledd via organisasjonsleddOver") {
+                val hierarki =
+                    EregOrganisasjon(
+                        organisasjonsnummer = "111111111",
+                        bestaarAvOrganisasjonsledd =
+                            listOf(
+                                EregOrganisasjonsleddWrapper(
+                                    organisasjonsledd =
+                                        EregOrganisasjonsledd(
+                                            organisasjonsnummer = "222222222",
+                                            organisasjonsleddOver =
+                                                listOf(
+                                                    EregOrganisasjonsleddWrapper(
+                                                        organisasjonsledd =
+                                                            EregOrganisasjonsledd(
+                                                                organisasjonsnummer = "333333333",
+                                                                inngaarIJuridiskEnheter =
+                                                                    listOf(EregEnhetsRelasjon("444444444")),
+                                                            ),
+                                                    ),
+                                                ),
+                                        ),
+                                ),
+                            ),
+                    )
+
+                hierarki.aggregerOrgnummereFraHierarki() shouldBe
+                    setOf("111111111", "222222222", "333333333", "444444444")
+            }
+
+            it("includes juridisk enhet directly from top-level inngaarIJuridiskEnheter (two-level underenhet)") {
+                val hierarki =
+                    EregOrganisasjon(
+                        organisasjonsnummer = "123456789",
+                        inngaarIJuridiskEnheter = listOf(EregEnhetsRelasjon("987654321")),
+                    )
+
+                hierarki.aggregerOrgnummereFraHierarki() shouldBe setOf("123456789", "987654321")
+            }
+
+            it("does not double-process a shared ancestor reached via two paths (visited guard)") {
+                val deltLedd =
+                    EregOrganisasjonsledd(
+                        organisasjonsnummer = "333333333",
+                        inngaarIJuridiskEnheter = listOf(EregEnhetsRelasjon("444444444")),
+                    )
+                val hierarki =
+                    EregOrganisasjon(
+                        organisasjonsnummer = "111111111",
+                        bestaarAvOrganisasjonsledd =
+                            listOf(
+                                EregOrganisasjonsleddWrapper(
+                                    organisasjonsledd =
+                                        EregOrganisasjonsledd(
+                                            organisasjonsnummer = "222222222",
+                                            organisasjonsleddOver =
+                                                listOf(
+                                                    EregOrganisasjonsleddWrapper(deltLedd),
+                                                    EregOrganisasjonsleddWrapper(deltLedd),
+                                                ),
+                                        ),
+                                ),
+                            ),
+                    )
+
+                hierarki.aggregerOrgnummereFraHierarki() shouldBe
+                    setOf("111111111", "222222222", "333333333", "444444444")
+            }
+
+            it("excludes a juridisk enhet whose gyldighetsperiode has expired") {
+                val hierarki =
+                    EregOrganisasjon(
+                        organisasjonsnummer = "895225282",
+                        inngaarIJuridiskEnheter =
+                            listOf(
+                                EregEnhetsRelasjon(
+                                    organisasjonsnummer = "938801363",
+                                    gyldighetsperiode = EregGyldighetsperiode(fom = "2000-01-01", tom = "2010-12-31"),
+                                ),
+                            ),
+                    )
+
+                hierarki.aggregerOrgnummereFraHierarki() shouldBe setOf("895225282")
+            }
+
+            it("excludes an organisasjonsledd whose gyldighetsperiode has expired") {
+                val hierarki =
+                    EregOrganisasjon(
+                        organisasjonsnummer = "895225282",
+                        bestaarAvOrganisasjonsledd =
+                            listOf(
+                                EregOrganisasjonsleddWrapper(
+                                    organisasjonsledd =
+                                        EregOrganisasjonsledd(
+                                            organisasjonsnummer = "976679512",
+                                            inngaarIJuridiskEnheter = listOf(EregEnhetsRelasjon("938801363")),
+                                        ),
+                                    gyldighetsperiode = EregGyldighetsperiode(fom = "2000-01-01", tom = "2010-12-31"),
+                                ),
+                            ),
+                    )
+
+                hierarki.aggregerOrgnummereFraHierarki() shouldBe setOf("895225282")
+            }
+        }
+    })

--- a/src/test/kotlin/no/nav/syfo/mockdata/TestApiModule.kt
+++ b/src/test/kotlin/no/nav/syfo/mockdata/TestApiModule.kt
@@ -15,6 +15,7 @@ import no.nav.syfo.client.aareg.domain.IdentType
 import no.nav.syfo.client.aareg.domain.Opplysningspliktig
 import no.nav.syfo.client.aareg.domain.OpplysningspliktigType
 import no.nav.syfo.client.dokarkiv.DokarkivClient
+import no.nav.syfo.client.ereg.EregClient
 import no.nav.syfo.client.isdialogmelding.IsdialogmeldingClient
 import no.nav.syfo.client.krrproxy.KrrProxyClient
 import no.nav.syfo.client.oppdfgen.OpPdfGenClient
@@ -35,6 +36,7 @@ fun Application.testApiModule(
     val isdialogmeldingClient = mockk<IsdialogmeldingClient>(relaxed = true)
     val followupPlanProducer = mockk<FollowUpPlanProducer>(relaxed = true)
     val dokarkivClient = mockk<DokarkivClient>(relaxed = true)
+    val eregClient = mockk<EregClient>(relaxed = true)
 
     val opPdfGenClient =
         OpPdfGenClient(
@@ -149,5 +151,6 @@ fun Application.testApiModule(
             ),
         sykmeldingService = sykmeldingService,
         arbeidsforholdOversiktClient = arbeidsforholdOversiktClient,
+        eregClient = eregClient,
     )
 }

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplanmottak/validation/FollowUpPlanValidatorTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplanmottak/validation/FollowUpPlanValidatorTest.kt
@@ -2,7 +2,9 @@ package no.nav.syfo.oppfolgingsplanmottak.validation
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
+import io.mockk.clearMocks
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.mockk
 import no.nav.syfo.application.exception.FollowUpPlanDTOValidationException
 import no.nav.syfo.application.exception.NoActiveEmploymentException
@@ -16,6 +18,11 @@ import no.nav.syfo.client.aareg.domain.Ident
 import no.nav.syfo.client.aareg.domain.IdentType
 import no.nav.syfo.client.aareg.domain.Opplysningspliktig
 import no.nav.syfo.client.aareg.domain.OpplysningspliktigType
+import no.nav.syfo.client.ereg.EregClient
+import no.nav.syfo.client.ereg.domain.EregEnhetsRelasjon
+import no.nav.syfo.client.ereg.domain.EregOrganisasjon
+import no.nav.syfo.client.ereg.domain.EregOrganisasjonsledd
+import no.nav.syfo.client.ereg.domain.EregOrganisasjonsleddWrapper
 import no.nav.syfo.client.pdl.PdlClient
 import no.nav.syfo.oppfolgingsplanmottak.domain.FollowUpPlanDTO
 import no.nav.syfo.sykmelding.domain.Sykmeldingsperiode
@@ -29,6 +36,7 @@ const val HOVEDENHET_ORGNUMBER = "987654321"
 const val OTHER_COMPANY_UNDERENHET_ORGNUMBER = "234567890"
 const val OTHER_COMPANY_HOVEDENHET_ORGNUMBER = "876543219"
 const val SECOND_UNDERENHET_ORGNUMBER = "111222333"
+const val ORGANISASJONSLEDD_ORGNUMBER = "456789012"
 const val EMPLOYEE_SSN = "12345678901"
 
 class FollowUpPlanValidatorTest :
@@ -36,9 +44,17 @@ class FollowUpPlanValidatorTest :
         val pdlClient = mockk<PdlClient>()
         val sykmeldingService = mockk<SendtSykmeldingService>()
         val arbeidsforholdOversiktClient = mockk<ArbeidsforholdOversiktClient>()
-        val validator = FollowUpPlanValidator(pdlClient, sykmeldingService, arbeidsforholdOversiktClient, false)
+        val eregClient = mockk<EregClient>()
+        val validator =
+            FollowUpPlanValidator(pdlClient, sykmeldingService, arbeidsforholdOversiktClient, eregClient, false)
 
         describe("FollowUpPlanValidator") {
+            // Reset eregClient before each test so per-test stubs cannot leak across the shared spec instance.
+            beforeTest {
+                clearMocks(eregClient)
+                coEvery { eregClient.getOrganisasjonHierarki(any()) } returns null
+            }
+
             context("validateFollowUpPlanDTO") {
                 it("should throw exception if needsHelpFromNav is true and sendPlanToNav is false") {
                     val followUpPlanDTO = createFollowUpPlanDTO(needsHelpFromNav = true, sendPlanToNav = false)
@@ -166,6 +182,129 @@ class FollowUpPlanValidatorTest :
                     } returns mockk()
 
                     validator.validateFollowUpPlanDTO(followUpPlanDTO, UNDERENHET_ORGNUMBER)
+                }
+
+                it(
+                    "should pass validation when orgnumber from token is an organisasjonsledd " +
+                        "between underenhet and hovedenhet (resolved via ereg hierarchy)",
+                ) {
+                    val followUpPlanDTO = createFollowUpPlanDTO()
+                    coEvery {
+                        sykmeldingService.getActiveSendtSykmeldingsperioder(any())
+                    } returns createValidSykmeldingsperioder()
+
+                    coEvery {
+                        arbeidsforholdOversiktClient.getArbeidsforhold(any())
+                    } returns createAaregArbeidsforhold(HOVEDENHET_ORGNUMBER, UNDERENHET_ORGNUMBER)
+
+                    coEvery {
+                        eregClient.getOrganisasjonHierarki(UNDERENHET_ORGNUMBER)
+                    } returns
+                        createEregOrganisasjonsleddHierarki(
+                            underenhet = UNDERENHET_ORGNUMBER,
+                            organisasjonsledd = ORGANISASJONSLEDD_ORGNUMBER,
+                            hovedenhet = HOVEDENHET_ORGNUMBER,
+                        )
+
+                    coEvery {
+                        pdlClient.getPersonInfo(any())
+                    } returns mockk()
+
+                    validator.validateFollowUpPlanDTO(followUpPlanDTO, ORGANISASJONSLEDD_ORGNUMBER)
+                }
+
+                it(
+                    "should throw exception when ereg hierarchy is populated but does not contain the token orgnumber",
+                ) {
+                    val followUpPlanDTO = createFollowUpPlanDTO()
+                    coEvery {
+                        sykmeldingService.getActiveSendtSykmeldingsperioder(any())
+                    } returns createValidSykmeldingsperioder()
+
+                    coEvery {
+                        arbeidsforholdOversiktClient.getArbeidsforhold(any())
+                    } returns createAaregArbeidsforhold(HOVEDENHET_ORGNUMBER, UNDERENHET_ORGNUMBER)
+
+                    coEvery {
+                        eregClient.getOrganisasjonHierarki(UNDERENHET_ORGNUMBER)
+                    } returns
+                        createEregOrganisasjonsleddHierarki(
+                            underenhet = UNDERENHET_ORGNUMBER,
+                            organisasjonsledd = ORGANISASJONSLEDD_ORGNUMBER,
+                            hovedenhet = HOVEDENHET_ORGNUMBER,
+                        )
+
+                    coEvery {
+                        pdlClient.getPersonInfo(any())
+                    } returns mockk()
+
+                    shouldThrow<NoActiveEmploymentException> {
+                        validator.validateFollowUpPlanDTO(followUpPlanDTO, OTHER_COMPANY_HOVEDENHET_ORGNUMBER)
+                    }
+                }
+
+                it("should not look up ereg for an arbeidssted without an organisasjonsnummer and throw") {
+                    val followUpPlanDTO = createFollowUpPlanDTO()
+                    coEvery {
+                        arbeidsforholdOversiktClient.getArbeidsforhold(any())
+                    } returns createPersonArbeidsstedArbeidsforhold()
+
+                    shouldThrow<NoActiveEmploymentException> {
+                        validator.validateFollowUpPlanDTO(followUpPlanDTO, HOVEDENHET_ORGNUMBER)
+                    }
+                    coVerify(exactly = 0) { eregClient.getOrganisasjonHierarki(any()) }
+                }
+
+                it(
+                    "should match only the arbeidssted whose ereg hierarchy contains the token org, " +
+                        "not sibling arbeidsforhold",
+                ) {
+                    val followUpPlanDTO = createFollowUpPlanDTO()
+                    coEvery {
+                        sykmeldingService.getActiveSendtSykmeldingsperioder(any())
+                    } returns createSykmeldingsperioder(organizationNumber = OTHER_COMPANY_UNDERENHET_ORGNUMBER)
+
+                    coEvery {
+                        arbeidsforholdOversiktClient.getArbeidsforhold(any())
+                    } returns
+                        AaregArbeidsforholdOversikt(
+                            listOf(
+                                createArbeidsforholdoversikt(UNDERENHET_ORGNUMBER, HOVEDENHET_ORGNUMBER),
+                                createArbeidsforholdoversikt(
+                                    OTHER_COMPANY_UNDERENHET_ORGNUMBER,
+                                    OTHER_COMPANY_HOVEDENHET_ORGNUMBER,
+                                ),
+                            ),
+                        )
+
+                    coEvery {
+                        eregClient.getOrganisasjonHierarki(UNDERENHET_ORGNUMBER)
+                    } returns
+                        createEregOrganisasjonsleddHierarki(
+                            underenhet = UNDERENHET_ORGNUMBER,
+                            organisasjonsledd = ORGANISASJONSLEDD_ORGNUMBER,
+                            hovedenhet = HOVEDENHET_ORGNUMBER,
+                        )
+
+                    coEvery {
+                        eregClient.getOrganisasjonHierarki(OTHER_COMPANY_UNDERENHET_ORGNUMBER)
+                    } returns
+                        createEregOrganisasjonsleddHierarki(
+                            underenhet = OTHER_COMPANY_UNDERENHET_ORGNUMBER,
+                            organisasjonsledd = SECOND_UNDERENHET_ORGNUMBER,
+                            hovedenhet = OTHER_COMPANY_HOVEDENHET_ORGNUMBER,
+                        )
+
+                    coEvery {
+                        pdlClient.getPersonInfo(any())
+                    } returns mockk()
+
+                    // Token org is only in UNDERENHET_ORGNUMBER's hierarchy, so only that arbeidsforhold matches.
+                    // OTHER_COMPANY_UNDERENHET_ORGNUMBER is therefore not a valid orgnumber, and a sykmelding
+                    // sent to it must be rejected (proves the hierarchy match does not leak to siblings).
+                    shouldThrow<NoActiveSentSykmeldingException> {
+                        validator.validateFollowUpPlanDTO(followUpPlanDTO, ORGANISASJONSLEDD_ORGNUMBER)
+                    }
                 }
 
                 it(
@@ -304,6 +443,49 @@ fun createMultipleAaregArbeidsforhold(): AaregArbeidsforholdOversikt =
         listOf(
             createArbeidsforholdoversikt(UNDERENHET_ORGNUMBER, HOVEDENHET_ORGNUMBER),
             createArbeidsforholdoversikt(SECOND_UNDERENHET_ORGNUMBER, HOVEDENHET_ORGNUMBER),
+        ),
+    )
+
+fun createEregOrganisasjonsleddHierarki(
+    underenhet: String,
+    organisasjonsledd: String,
+    hovedenhet: String,
+): EregOrganisasjon =
+    EregOrganisasjon(
+        organisasjonsnummer = underenhet,
+        bestaarAvOrganisasjonsledd =
+            listOf(
+                EregOrganisasjonsleddWrapper(
+                    organisasjonsledd =
+                        EregOrganisasjonsledd(
+                            organisasjonsnummer = organisasjonsledd,
+                            inngaarIJuridiskEnheter = listOf(EregEnhetsRelasjon(hovedenhet)),
+                        ),
+                ),
+            ),
+    )
+
+fun createPersonArbeidsstedArbeidsforhold(): AaregArbeidsforholdOversikt =
+    AaregArbeidsforholdOversikt(
+        listOf(
+            Arbeidsforholdoversikt(
+                arbeidssted =
+                    Arbeidssted(
+                        type = ArbeidsstedType.Person,
+                        identer =
+                            listOf(
+                                Ident(type = IdentType.FOLKEREGISTERIDENT, ident = EMPLOYEE_SSN, gjeldende = true),
+                            ),
+                    ),
+                opplysningspliktig =
+                    Opplysningspliktig(
+                        type = OpplysningspliktigType.Person,
+                        identer =
+                            listOf(
+                                Ident(type = IdentType.FOLKEREGISTERIDENT, ident = "12345678902", gjeldende = true),
+                            ),
+                    ),
+            ),
         ),
     )
 


### PR DESCRIPTION
## Beskrivelse

Innsending av oppfølgingsplan feilet med `NoActiveEmploymentException` ("No active employment relationship found for given orgnumber") for enkelte kommunekunder.

Org.nummeret som valideres kommer fra `consumer`-claimet i Maskinporten-tokenet. For store offentlige arbeidsgivere kan dette være et **organisasjonsledd** som ligger mellom underenheten (arbeidsstedet) og den juridiske enheten:

```
938801363  juridisk enhet (KOMM)            ← aareg: opplysningspliktig
   └─ 976679512  organisasjonsledd (ORGL)    ← token consumer  ✗ ble avvist
        └─ 895225282  underenhet (BEDR)       ← aareg: arbeidssted
```

aaregs `arbeidsforholdoversikt` er to-nivå (arbeidssted + opplysningspliktig/juridisk enhet) og utelater organisasjonsleddet. Valideringen godtok kun direkte treff mot disse to nivåene, og avviste dermed et gyldig mellomliggende organisasjonsledd — selv om den ansatte faktisk er ansatt under det.

## Endringer

- `FollowUpPlanValidator`: når det ikke er direkte treff mot arbeidssted eller juridisk enhet, slås arbeidsstedets hierarki opp i ereg, og org.nummeret godtas hvis det er en gyldig overordnet enhet. Ett oppslag per unikt arbeidssted.
- `EregClient`: ny `getOrganisasjonHierarki()` (`?inkluderHierarki=true`); felles request-helper for å unngå duplisert auth/header-oppsett; `404` → `null` (genuint fravær → korrekt å avvise), annen feilstatus → kastes slik at en forbigående ereg-feil blir `500` (kan prøves på nytt) i stedet for et villedende `403`.
- `EregOrganisasjonHierarki` (ny): modell + `aggregerOrgnummereFraHierarki()` som kun vandrer **oppover** (juridiske enheter og organisasjonsledd, rekursivt) med syklusvern. Utløpte relasjoner (`gyldighetsperiode.tom` i fortid) ekskluderes, slik at et avsluttet tilhørighetsforhold ikke gir tilgang.
- Wiring: `eregClient` tres inn i validatoren via `ApiModule`/`App`.

## Test

- Positivt scenario: organisasjonsledd mellom underenhet og juridisk enhet godtas.
- Negativt scenario: et populert hierarki som **ikke** inneholder token-org avvises.
- Ingen lekkasje: hierarki-treff for én underenhet godtar ikke sideordnede arbeidsforhold.
- Utløpte relasjoner ekskluderes; arbeidssted uten org.nummer slår ikke opp ereg.
- 82 tester grønne (ktlint + spotless OK).

## Sjekkliste

- [x] Koden kompilerer og linter uten feil (ktlint + spotless)
- [x] Endringene er testet (82 tester grønne, inkl. nye)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)
